### PR TITLE
Fix `item.starttls` for `nullmailer__remotes` which was ignored

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,12 @@ The current role maintainer_ is drybjed_.
 
 .. _debops.nullmailer master: https://github.com/debops/ansible-nullmailer/compare/v0.1.0...master
 
+Fixed
+~~~~~
+
+- Fix ``item.starttls`` for ``nullmailer__remotes`` which was ignored
+  previously when set to ``False``. [ypid_]
+
 
 debops.nullmailer v0.1.0 - 2016-07-26
 -------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,7 @@ The current role maintainer_ is drybjed_.
 Fixed
 ~~~~~
 
-- Fix ``item.starttls`` for ``nullmailer__remotes`` which was ignored
+- Fix ``item.starttls`` for :envvar:`nullmailer__remotes` which was ignored
   previously when set to ``False``. [ypid_]
 
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ into your playbook.
 
 ### Authors and license
 
-- Maciej Delmanowski (maintainer) | [e-mail](mailto:drybjed@gmail.com) | [Twitter](https://twitter.com/drybjed) | [GitHub](https://github.com/drybjed)
+- [Maciej Delmanowski](https://docs.debops.org/en/latest/debops-keyring/docs/entities.html#debops-keyring-entity-drybjed) (maintainer) | [e-mail](mailto:drybjed@gmail.com) | [Twitter](https://twitter.com/drybjed) | [GitHub](https://github.com/drybjed)
 
 License: [GPL-3.0](https://tldrlegal.com/license/gnu-general-public-license-v3-%28gpl-3%29)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -330,7 +330,7 @@ nullmailer__ferm__dependent_rules:
                         nullmailer__smtpd|bool) else "absent" }}'
 
                                                                    # ]]]
-# .. envvar:: nullmailer__tcpwrapper__dependent_allow [[[
+# .. envvar:: nullmailer__tcpwrappers__dependent_allow [[[
 #
 # Configuration for the debops.tcpwrappers_ Ansible role.
 nullmailer__tcpwrappers__dependent_allow:

--- a/meta/ansigenome.yml
+++ b/meta/ansigenome.yml
@@ -11,7 +11,6 @@ ansigenome_info:
 
   authors:
     - name:  'Maciej Delmanowski'
-      url: ''
       email: 'drybjed@gmail.com'
       twitter: 'drybjed'
       github: 'drybjed'
@@ -20,10 +19,10 @@ ansigenome_info:
     The [nullmailer](http://untroubled.org/nullmailer/) package can be used to
     setup a forwarding SMTP relay. It does not provide support for local mail, but
     forwards all messages to one or more remote SMTP servers for processing.
-    
+
     The `debops.nullmailer` role installs and configures the `nullmailer`
     service, optionally with a network access from remote hosts on port 25.
-    
+
     The role can detect other Mail Transport Agents installed on the managed host,
     and if an MTA from a configurable list is found, the role will automatically
     disable itself to allow easy switch to different SMTP servers.

--- a/templates/lookup/nullmailer__remotes.j2
+++ b/templates/lookup/nullmailer__remotes.j2
@@ -7,7 +7,7 @@
 {%     if entry.host|d() %}
 {%       set _ = nullmailer__tpl_entry.append(entry.host) %}
 {%       set _ = nullmailer__tpl_entry.append(entry.protocol|d('smtp')) %}
-{%       if (((entry.starttls|d() and entry.starttls|bool) or nullmailer__starttls|bool) and (entry.ssl is undefined or not entry.ssl|bool) and (entry.options is undefined or not entry.options)) %}
+{%       if ((entry.starttls|d(nullmailer__starttls)|bool) and (not entry.ssl|d()|bool) and (not entry.options|d())) %}
 {%         set _ = nullmailer__tpl_entry.append('--starttls') %}
 {%       endif %}
 {%       if entry.ssl|d() and entry.ssl|bool %}

--- a/templates/lookup/nullmailer__remotes.j2
+++ b/templates/lookup/nullmailer__remotes.j2
@@ -10,13 +10,13 @@
 {%       if ((entry.starttls|d(nullmailer__starttls)|bool) and (not entry.ssl|d()|bool) and (not entry.options|d())) %}
 {%         set _ = nullmailer__tpl_entry.append('--starttls') %}
 {%       endif %}
-{%       if entry.ssl|d() and entry.ssl|bool %}
+{%       if entry.ssl|d()|bool %}
 {%         set _ = nullmailer__tpl_entry.append('--ssl') %}
 {%       endif %}
-{%       if entry.insecure|d() and entry.insecure|bool %}
+{%       if entry.insecure|d()|bool %}
 {%         set _ = nullmailer__tpl_entry.append('--insecure') %}
 {%       endif %}
-{%       if entry.x509fmtder|d() and entry.x509fmtder|bool %}
+{%       if entry.x509fmtder|d()|bool %}
 {%         set _ = nullmailer__tpl_entry.append('--x509fmtder') %}
 {%       endif %}
 {%       if entry.x509cafile|d() %}
@@ -31,7 +31,7 @@
 {%       if entry.port|d() %}
 {%         set _ = nullmailer__tpl_entry.append('--port=' + entry.port) %}
 {%       endif %}
-{%       if ((entry.auth|d() and entry.auth|bool) or (entry.auth_login|d() and entry.auth_login|bool)) %}
+{%       if ((entry.auth|d()|bool) or (entry.auth_login|d()|bool)) %}
 {%         set _ = nullmailer__tpl_entry.append('--auth-login') %}
 {%       endif %}
 {%       if entry.user|d() %}

--- a/templates/usr/local/lib/debops-nullmailer-dpkg-cleanup.j2
+++ b/templates/usr/local/lib/debops-nullmailer-dpkg-cleanup.j2
@@ -4,7 +4,7 @@
 
 # Clean up 'debops.nullmailer' modifications on the 'nullmailer' package purge
 
-set -eu -o pipefail
+set -o nounset -o pipefail -o errexit
 
 purge_files=(
 {% for element in (nullmailer__configuration_files + nullmailer__private_configuration_files + nullmailer__purge_default_files + nullmailer__purge_files) %}


### PR DESCRIPTION
I don’t judge you for not testing this feature. It should not be needed, but sometimes it is unfortunately (internally only obviously).