### PR TITLE
always_run is deprecated. Use check_mode = no instead..

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,7 @@ Fixed
 - Fix ``item.starttls`` for :envvar:`nullmailer__remotes` which was ignored
   previously when set to ``False``. [ypid_]
 
-- Fix Ansible 2.2 deprecation warnings. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
 
 
 debops.nullmailer v0.1.0 - 2016-07-26

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,8 @@ Fixed
 - Fix ``item.starttls`` for :envvar:`nullmailer__remotes` which was ignored
   previously when set to ``False``. [ypid_]
 
-- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher.
+  Support for older Ansible versions is dropped. [brzhk]
 
 
 debops.nullmailer v0.1.0 - 2016-07-26

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,8 @@ Fixed
 - Fix ``item.starttls`` for :envvar:`nullmailer__remotes` which was ignored
   previously when set to ``False``. [ypid_]
 
+- Fix Ansible 2.2 deprecation warnings. [brzhk]
+
 
 debops.nullmailer v0.1.0 - 2016-07-26
 -------------------------------------

--- a/env/tasks/main.yml
+++ b/env/tasks/main.yml
@@ -7,7 +7,7 @@
   register: nullmailer__register_mta
   changed_when: False
   failed_when: False
-  check_mode: no
+  check_mode: False
 
 - name: Set nullmailer deployment state
   set_fact:

--- a/env/tasks/main.yml
+++ b/env/tasks/main.yml
@@ -7,7 +7,7 @@
   register: nullmailer__register_mta
   changed_when: False
   failed_when: False
-  always_run: True
+  check_mode: no
 
 - name: Set nullmailer deployment state
   set_fact:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   description: 'Manage nullmailer SMTP server'
   company: 'DebOps'
   license: 'GPL-3.0'
-  min_ansible_version: '2.0.0'
+  min_ansible_version: '2.2.0'
   platforms:
   - name: Ubuntu
     versions:


### PR DESCRIPTION
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.